### PR TITLE
Added possibility to define multiple authorized keys

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "${BORG_GID}" ]; then
 fi
 
 if [ ! -z ${BORG_AUTHORIZED_KEYS+x} ]; then
-    echo $BORG_AUTHORIZED_KEYS > /home/borg/.ssh/authorized_keys
+    echo -e $BORG_AUTHORIZED_KEYS > /home/borg/.ssh/authorized_keys
     chown borg.borg /home/borg/.ssh/authorized_keys
     chmod og-rwx /home/borg/.ssh/authorized_keys
 fi


### PR DESCRIPTION
I am doing borg backups from several users from same&different machines, so I need to be able to add multiple authorized keys into the /home/borg/.ssh/authorized_keys file.

With the "-e" flag, echo can interpret e.g. \n and would add a newline. Defining BORG_AUTHORIZED_KEYS='ssh-rsa AA... PC-1\nssh-rsa BB... PC-2\nssh-rsa CC... PC-3' will result in
```
ssh-rsa AA... PC-1
ssh-rsa BB... PC-2
ssh-rsa CC... PC-3
```