### PR TITLE
Fix UID 1000 being occupied by "ubuntu" user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
         libxxhash-dev \
         libzstd-dev \
     && apt-get autoremove -y --purge \
+    && userdel -r ubuntu \
     && adduser --uid 500 --disabled-password --gecos "Borg Backup" --quiet borg \
     && mkdir -p /var/run/sshd /var/backups/borg /var/lib/docker-borg/ssh mkdir /home/borg/.ssh \
     && chown borg.borg /var/backups/borg /home/borg/.ssh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
     && userdel -r ubuntu \
     && adduser --uid 500 --disabled-password --gecos "Borg Backup" --quiet borg \
     && mkdir -p /var/run/sshd /var/backups/borg /var/lib/docker-borg/ssh mkdir /home/borg/.ssh \
-    && chown borg.borg /var/backups/borg /home/borg/.ssh \
+    && chown borg:borg /var/backups/borg /home/borg/.ssh \
     && chmod 700 /home/borg/.ssh \
     && rm -rf /var/lib/apt/lists/*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,11 +24,11 @@ fi
 
 if [ ! -z ${BORG_AUTHORIZED_KEYS+x} ]; then
     echo -e "${BORG_AUTHORIZED_KEYS}" > /home/borg/.ssh/authorized_keys
-    chown borg.borg /home/borg/.ssh/authorized_keys
+    chown borg:borg /home/borg/.ssh/authorized_keys
     chmod og-rwx /home/borg/.ssh/authorized_keys
 fi
 
-chown -R borg.borg /home/borg
-chown -R borg.borg /home/borg/.ssh
+chown -R borg:borg /home/borg
+chown -R borg:borg /home/borg/.ssh
 
 exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
The Ubuntu 24.04 base image now comes with a default user `ubuntu` that has a uid of `1000`.
This breaks the ability to use uid `1000` for the `BORG_UID` environment variable because this uid is now occupied by the default user.

Also fixes some log warnings relating to `chown`.